### PR TITLE
Create missing directories on unpack

### DIFF
--- a/src/armake/pbo.rs
+++ b/src/armake/pbo.rs
@@ -328,6 +328,7 @@ pub fn cmd_unpack<I: Read>(input: &mut I, output: PathBuf) -> Result<(), Error> 
     for (file_name, cursor) in pbo.files.iter() {
         // @todo: windows
         let path = output.join(PathBuf::from(file_name.replace("\\", pathsep())));
+        create_dir_all(path.parent().unwrap().prepend_error("Failed to create output folder:")?;
         let mut file = File::create(path).prepend_error("Failed to open output file:")?;
         file.write_all(cursor.get_ref()).prepend_error("Failed to write output file:")?;
     }

--- a/src/armake/pbo.rs
+++ b/src/armake/pbo.rs
@@ -328,7 +328,7 @@ pub fn cmd_unpack<I: Read>(input: &mut I, output: PathBuf) -> Result<(), Error> 
     for (file_name, cursor) in pbo.files.iter() {
         // @todo: windows
         let path = output.join(PathBuf::from(file_name.replace("\\", pathsep())));
-        create_dir_all(path.parent().unwrap().prepend_error("Failed to create output folder:")?;
+        create_dir_all(path.parent().unwrap()).prepend_error("Failed to create output folder:")?;
         let mut file = File::create(path).prepend_error("Failed to open output file:")?;
         file.write_all(cursor.get_ref()).prepend_error("Failed to write output file:")?;
     }


### PR DESCRIPTION
**When merged this pull request will:**

Fix an issue with the unpack command. Rust does not automatically create required subdirectories on File::create (https://doc.rust-lang.org/std/fs/struct.File.html#method.create).
Thus it is required to first create the directory itself.

Only tested this on Linux.