### PR TITLE
Fixed windows-NL problem in read_prefix

### DIFF
--- a/src/pbo.rs
+++ b/src/pbo.rs
@@ -144,7 +144,7 @@ impl PBO {
             if name == "$PBOPREFIX$" {
                 let mut content = String::new();
                 file.read_to_string(&mut content)?;
-                for l in content.split("\n") {
+                for l in content.replace("\r\n","\n").split("\n") {
                     if l.len() == 0 { break; }
 
                     let eq: Vec<String> = l.split("=").map(|s| s.to_string()).collect();

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -239,7 +239,7 @@ fn read_prefix(prefix_path: &Path) -> String {
     let mut content = String::new();
     File::open(prefix_path).unwrap().read_to_string(&mut content).unwrap();
 
-    content.split("\n").nth(0).unwrap().to_string()
+    content.replace("\r\n","\n").split("\n").nth(0).unwrap().to_string()
 }
 
 pub fn pathsep() -> &'static str {


### PR DESCRIPTION
read_prefix was getting into trouble when windows NLs are ebing used inside the prefix file as it splitted the content at `\n` only so that the `\r` remained as part of the prefix - which is obviously wrong.

Fixes #8 #20