### PR TITLE
Implement verbose flag for warnings

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ use colored::*;
 use crate::config::*;
 use crate::preprocess::*;
 
-const WARNING_MAXIMUM: u32 = 10;
+pub static mut WARNING_MAXIMUM: u32 = 10;
 static mut WARNINGS_RAISED: Option<HashMap<String, u32>> = None;
 pub static mut WARNINGS_MUTED: Option<HashSet<String>> = None;
 
@@ -178,8 +178,8 @@ pub fn print_warning_summary() -> () {
         for (name, raised) in WARNINGS_RAISED.as_ref().unwrap().iter() {
             if WARNINGS_MUTED.as_ref().unwrap().contains(name) { continue; }
 
-            let excess = (*raised as i32) - (WARNING_MAXIMUM as i32);
-            if excess <= 0 { continue; }
+            if *raised <= WARNING_MAXIMUM { continue; }
+            let excess = *raised - WARNING_MAXIMUM;
 
             if excess > 1 {
                 warning(format!("{} warnings of type \"{}\" were suppressed to prevent spam. Use \"-w {}\" to disable these warnings entirely.",

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ use colored::*;
 use crate::config::*;
 use crate::preprocess::*;
 
-pub static mut WARNING_MAXIMUM: u32 = 10;
+pub static mut WARNINGS_MAXIMUM: u32 = 10;
 static mut WARNINGS_RAISED: Option<HashMap<String, u32>> = None;
 pub static mut WARNINGS_MUTED: Option<HashSet<String>> = None;
 
@@ -118,7 +118,7 @@ pub fn warning<M: AsRef<[u8]> + Display>(msg: M, name: Option<&'static str>, loc
             let raised = WARNINGS_RAISED.as_ref().unwrap().get(name).unwrap_or(&0);
             WARNINGS_RAISED.as_mut().unwrap().insert(name.to_string(), raised + 1);
 
-            if raised >= &WARNING_MAXIMUM {
+            if raised >= &WARNINGS_MAXIMUM {
                 return;
             }
 
@@ -162,7 +162,7 @@ pub fn warning_suppressed(name: Option<&'static str>) -> bool {
 
         if WARNINGS_RAISED.is_some() {
             let raised = WARNINGS_RAISED.as_ref().unwrap().get(name.unwrap()).unwrap_or(&0);
-            raised >= &WARNING_MAXIMUM
+            raised >= &WARNINGS_MAXIMUM
         } else {
             false
         }
@@ -178,8 +178,8 @@ pub fn print_warning_summary() -> () {
         for (name, raised) in WARNINGS_RAISED.as_ref().unwrap().iter() {
             if WARNINGS_MUTED.as_ref().unwrap().contains(name) { continue; }
 
-            if *raised <= WARNING_MAXIMUM { continue; }
-            let excess = *raised - WARNING_MAXIMUM;
+            if *raised <= WARNINGS_MAXIMUM { continue; }
+            let excess = *raised - WARNINGS_MAXIMUM;
 
             if excess > 1 {
                 warning(format!("{} warnings of type \"{}\" were suppressed to prevent spam. Use \"-w {}\" to disable these warnings entirely.",

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,7 @@ fn main() {
     unsafe {
         WARNINGS_MUTED = Some(HashSet::from_iter(args.flag_warning.clone()));
         if args.flag_verbose {
-            WARNING_MAXIMUM = std::u32::MAX;
+            WARNINGS_MAXIMUM = std::u32::MAX;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,9 @@ fn main() {
 
     unsafe {
         WARNINGS_MUTED = Some(HashSet::from_iter(args.flag_warning.clone()));
+        if args.flag_verbose {
+            WARNING_MAXIMUM = std::u32::MAX;
+        }
     }
 
     run_command(&args).print_error(true);


### PR DESCRIPTION
Will print all warnings (or rather `u32::MAX` of them).

Also renamed `WARNING_MAXIMUM` to `WARNINGS_MAXIMUM`.