### PR TITLE
Move preprocess into iterator

### DIFF
--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -359,7 +359,7 @@ pub fn find_include_file(include_path: &String, origin: Option<&PathBuf>, search
     }
 }
 
-fn line_muncher(line: &Line, original_lineno: &mut u32, level: &mut u32, level_true: &mut u32, input: String, origin: Option<PathBuf>, definition_map: &mut HashMap<String, Definition>, info: &mut PreprocessInfo, includefolders: &Vec<PathBuf>) -> Result<String, Error> {
+fn line_muncher(line: &Line, original_lineno: &mut u32, level: &mut u32, level_true: &mut u32, origin: Option<PathBuf>, definition_map: &mut HashMap<String, Definition>, info: &mut PreprocessInfo, includefolders: &Vec<PathBuf>) -> Result<String, Error> {
     let mut output = String::from("");
     match line {
         Line::DirectiveLine(dir) => match dir {
@@ -453,7 +453,6 @@ fn line_muncher(line: &Line, original_lineno: &mut u32, level: &mut u32, level_t
 }
 
 pub struct PreprocessHolder<'a> {
-    pub input: String,
     pub origin: Option<PathBuf>,
     pub definition_map: &'a mut HashMap<String, Definition>,
     pub info: &'a mut PreprocessInfo,
@@ -475,7 +474,6 @@ impl<'a> Iterator for PreprocessHolder<'a> {
                     &mut self.original_lineno,
                     &mut self.level,
                     &mut self.level_true,
-                    self.input.clone(),
                     self.origin.clone(),
                     &mut self.definition_map,
                     &mut self.info,
@@ -502,7 +500,6 @@ fn preprocess_rec(input: String, origin: Option<PathBuf>, definition_map: &mut H
         original_lineno: &mut original_lineno,
         level: &mut level,
         level_true: &mut level_true,
-        input: input.clone(),
         origin: origin.clone(),
         definition_map, // Surely this needs to be mutable?
         info,

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -359,6 +359,99 @@ pub fn find_include_file(include_path: &String, origin: Option<&PathBuf>, search
     }
 }
 
+fn line_muncher(line:Line, original_lineno: &mut u32, level: &mut u32, level_true: &mut u32, input: String, origin: Option<PathBuf>, definition_map: &mut HashMap<String, Definition>, info: &mut PreprocessInfo, includefolders: &Vec<PathBuf>) -> Result<String, Error> {
+    let mut output = String::from("");
+    match line {
+        Line::DirectiveLine(dir) => match dir {
+            Directive::IncludeDirective(path) => {
+                if *level > *level_true { return Ok(output.to_string()); }
+
+                //let import_tree = &mut info.import_tree;
+                //let includer = import_tree.get(&path);
+                //if let Some(path) = includer {
+                //    // @todo: complain
+                //}
+
+                let file_path = find_include_file(&path, origin.as_ref(), includefolders)?;
+
+                info.import_stack.push(file_path.clone());
+
+                let mut content = String::new();
+                File::open(&file_path)?.read_to_string(&mut content)?;
+                let result = preprocess_rec(content, Some(file_path), definition_map, info, includefolders).prepend_error(format!("Failed to preprocess include \"{}\":", path))?;
+
+                info.import_stack.pop();
+
+                output += &result;
+            },
+            Directive::DefineDirective(def) => {
+                *original_lineno += u32::sum(def.value.iter().map(|t| match t {
+                    Token::NewlineToken(_s, n) => *n,
+                    Token::CommentToken(n) => *n,
+                    _ => 0
+                }));
+
+                if *level > *level_true { return Ok(output.to_string()); }
+
+                if definition_map.remove(&def.name).is_some() {
+                    // @todo: warn about redefine
+                }
+
+                definition_map.insert(def.name.clone(), def);
+            }
+            Directive::UndefDirective(name) => {
+                if *level > *level_true { return Ok(output.to_string()); }
+
+                definition_map.remove(&name);
+            }
+            Directive::IfDefDirective(name) => {
+                *level_true += if *level_true == *level && definition_map.contains_key(&name) { 1 } else { 0 };
+                *level += 1;
+            }
+            Directive::IfNDefDirective(name) => {
+                *level_true += if *level_true == *level && !definition_map.contains_key(&name) { 1 } else { 0 };
+                *level += 1;
+            }
+            Directive::ElseDirective => {
+                if *level_true + 1 == *level {
+                    *level_true = *level;
+                } else if *level_true == *level {
+                    *level_true -= 1;
+                }
+            }
+            Directive::EndIfDirective => {
+                assert!(*level > 0);
+                *level -= 1;
+                if *level_true > *level {
+                    *level_true -= 1;
+                }
+            }
+        },
+        Line::TokenLine(tokens) => {
+            let stack: Vec<Definition> = Vec::new();
+            let resolved = Macro::resolve_all(&tokens, &definition_map, &stack).prepend_error("Failed to resolve macros:")?;
+
+            let (mut result, newlines) = Token::concat(&resolved);
+            result = result.replace("\r\n", "\n").replace("\\\n", "");
+            *original_lineno += newlines;
+
+            if *level > *level_true { return Ok(output.to_string()); }
+
+            output += &result;
+            output += "\n";
+
+            info.line_origins.push((*original_lineno, origin.clone()));
+        }
+    }
+    *original_lineno += 1;
+
+    if *level > 0 {
+        // @todo: complain
+    }
+
+    Ok(output.to_string())
+}
+
 struct PreprocessHolder<'a> {
     input: String,
     origin: Option<PathBuf>,
@@ -376,98 +469,6 @@ impl<'a> Iterator for PreprocessHolder<'a> {
     }
 }
 
-fn line_muncher(line:Line, original_lineno: &mut u32, level: &mut u32, level_true: &mut u32, input: String, origin: Option<PathBuf>, definition_map: &mut HashMap<String, Definition>, info: &mut PreprocessInfo, includefolders: &Vec<PathBuf>) -> Result<String, Error> {
-    let mut output = String::from("");
-        match line {
-            Line::DirectiveLine(dir) => match dir {
-                Directive::IncludeDirective(path) => {
-                    if *level > *level_true { return Ok(output.to_string()); }
-
-                    //let import_tree = &mut info.import_tree;
-                    //let includer = import_tree.get(&path);
-                    //if let Some(path) = includer {
-                    //    // @todo: complain
-                    //}
-
-                    let file_path = find_include_file(&path, origin.as_ref(), includefolders)?;
-
-                    info.import_stack.push(file_path.clone());
-
-                    let mut content = String::new();
-                    File::open(&file_path)?.read_to_string(&mut content)?;
-                    let result = preprocess_rec(content, Some(file_path), definition_map, info, includefolders).prepend_error(format!("Failed to preprocess include \"{}\":", path))?;
-
-                    info.import_stack.pop();
-
-                    output += &result;
-                },
-                Directive::DefineDirective(def) => {
-                    *original_lineno += u32::sum(def.value.iter().map(|t| match t {
-                        Token::NewlineToken(_s, n) => *n,
-                        Token::CommentToken(n) => *n,
-                        _ => 0
-                    }));
-
-                    if *level > *level_true { return Ok(output.to_string()); }
-
-                    if definition_map.remove(&def.name).is_some() {
-                        // @todo: warn about redefine
-                    }
-
-                    definition_map.insert(def.name.clone(), def);
-                }
-                Directive::UndefDirective(name) => {
-                    if *level > *level_true { return Ok(output.to_string()); }
-
-                    definition_map.remove(&name);
-                }
-                Directive::IfDefDirective(name) => {
-                    *level_true += if *level_true == *level && definition_map.contains_key(&name) { 1 } else { 0 };
-                    *level += 1;
-                }
-                Directive::IfNDefDirective(name) => {
-                    *level_true += if *level_true == *level && !definition_map.contains_key(&name) { 1 } else { 0 };
-                    *level += 1;
-                }
-                Directive::ElseDirective => {
-                    if *level_true + 1 == *level {
-                        *level_true = *level;
-                    } else if *level_true == *level {
-                        *level_true -= 1;
-                    }
-                }
-                Directive::EndIfDirective => {
-                    assert!(*level > 0);
-                    *level -= 1;
-                    if *level_true > *level {
-                        *level_true -= 1;
-                    }
-                }
-            },
-            Line::TokenLine(tokens) => {
-                let stack: Vec<Definition> = Vec::new();
-                let resolved = Macro::resolve_all(&tokens, &definition_map, &stack).prepend_error("Failed to resolve macros:")?;
-
-                let (mut result, newlines) = Token::concat(&resolved);
-                result = result.replace("\r\n", "\n").replace("\\\n", "");
-                *original_lineno += newlines;
-
-                if *level > *level_true { return Ok(output.to_string()); }
-
-                output += &result;
-                output += "\n";
-
-                info.line_origins.push((*original_lineno, origin.clone()));
-            }
-        }
-        *original_lineno += 1;
-
-        if *level > 0 {
-            // @todo: complain
-        }
-
-        Ok(output.to_string())
-}
 
 fn preprocess_rec(input: String, origin: Option<PathBuf>, definition_map: &mut HashMap<String, Definition>, info: &mut PreprocessInfo, includefolders: &Vec<PathBuf>) -> Result<String, Error> {
     let lines = preprocess_grammar::file(&input).format_error(&origin, &input)?;

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -484,23 +484,17 @@ impl<'a> Iterator for PreprocessHolder<'a> {
 
 fn preprocess_rec(input: String, origin: Option<PathBuf>, definition_map: &mut HashMap<String, Definition>, info: &mut PreprocessInfo, includefolders: &Vec<PathBuf>) -> Result<String, Error> {
     let lines = preprocess_grammar::file(&input).format_error(&origin, &input)?;
-    let mut output = String::from("");
 
-    let pp = PreprocessHolder{
+    let output = PreprocessHolder{
         line: lines.iter(),
         original_lineno: 1,
         level: 0,
         level_true: 0,
         origin: origin.clone(),
-        definition_map, // Surely this needs to be mutable?
+        definition_map,
         info,
         includefolders
-    };
-
-    for line in pp {
-        output += &line;
-    }
-
+    }.fold("".to_string(), |acc, x| acc + &x);
     Ok(output)
 }
 

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -466,11 +466,10 @@ pub struct PreprocessHolder<'a> {
 impl<'a> Iterator for PreprocessHolder<'a> {
     type Item = String;
     fn next(&mut self) -> Option<Self::Item> {
-        let line = self.line.next(); // Will this actually change self.line() for the next step?
-        match line {
-            Some(x) => {
+        match self.line.next() {
+            Some(line) => {
                 Some(line_muncher(
-                    x,
+                    line,
                     &mut self.original_lineno,
                     &mut self.level,
                     &mut self.level_true,

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -453,15 +453,15 @@ fn line_muncher(line: &Line, original_lineno: &mut u32, level: &mut u32, level_t
 }
 
 pub struct PreprocessHolder<'a> {
-    input: String,
-    origin: Option<PathBuf>,
-    definition_map: &'a mut HashMap<String, Definition>,
-    info: &'a mut PreprocessInfo,
-    includefolders: &'a Vec<PathBuf>,
-    original_lineno: &'a mut u32,
-    level: &'a mut u32,
-    level_true: &'a mut u32,
-    line: std::slice::Iter<'a, Line>,
+    pub input: String,
+    pub origin: Option<PathBuf>,
+    pub definition_map: &'a mut HashMap<String, Definition>,
+    pub info: &'a mut PreprocessInfo,
+    pub includefolders: &'a Vec<PathBuf>,
+    pub original_lineno: &'a mut u32,
+    pub level: &'a mut u32,
+    pub level_true: &'a mut u32,
+    pub line: std::slice::Iter<'a, Line>,
 }
 
 impl<'a> Iterator for PreprocessHolder<'a> {


### PR DESCRIPTION
Disclaimer: I don't "get" Rust so a lot of what I do here might be mad. I probably listen to the compiler a little too much.

To my surprise, the PR does work.

Summary of changes:

- I've moved most of the loop body in `preprocess_rec` out into the `line_muncher` function
   - I've made things mutable where it seemed prudent
- I made an iterator, `PreprocessHolder`, that calls the `line_muncher` function and keeps track of the current line
- I made `preprocess_rec` use that iterator

Motivation: https://github.com/synixebrett/HEMTT/pull/57


Even on a large config, it hasn't degraded performance:

```sh
bash-5.0$ time ~/projects/armake2/target/debug/armake2 preprocess addons/weapon_rifle_blank_c/config.cpp  > iterator_v.txt

real    0m4.193s
user    0m4.136s
sys     0m0.050s
bash-5.0$ time ~/projects/armake2/target/debug/armake2 preprocess addons/weapon_rifle_blank_c/config.cpp  > master_branch.txt

real    0m4.175s
user    0m4.111s
sys     0m0.057s
```

The final loop could obviously be replaced with a `fold` if you're so inclined.


I'd appreciate someone who knows what they're doing looking over this - the dereferences everywhere look like an anti-pattern, for example. Also, help with naming things would be useful.


I'm happy to tidy the PR up before (if?) it is merged.